### PR TITLE
Exercise: Refining Shuttle.

### DIFF
--- a/notebooks/classes.ipynb
+++ b/notebooks/classes.ipynb
@@ -1354,7 +1354,13 @@
       "- Create a Student object, and prove that you have used inheritance correctly.\n",
       "    - Set some attribute values for the student, that are only coded in the Person class.\n",
       "    - Set some attribute values for the student, that are only coded in the Student class.\n",
-      "    - Print the values for all of these attributes."
+      "    - Print the values for all of these attributes.\n",
+      "\n",
+      "#### Refining Shuttle\n",
+      "- Take the latest version of the [Shuttle class](#shuttle). Extend it.\n",
+      "    - Add more attributes that are particular to shuttles such as maximum number of flights, capability of supporting spacewalks, and capability of docking with the ISS.\n",
+      "    - Add one more method to the class, that relates to shuttle behavior. This method could simply print a statement, such as \"Docking with the ISS,\" for a dock_ISS() method.\n",
+      "    - Prove that your refinements work by creating a Shuttle object with these attributes, and then call your new method."
      ]
     },
     {
@@ -1363,6 +1369,71 @@
      "source": [
       "[top](#)"
      ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "<a name='importing'></a>Importing classes\n",
+      "==="
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "from math import sqrt\n",
+      "\n",
+      "class Rocket():\n",
+      "    # Rocket simulates a rocket ship for a game,\n",
+      "    #  or a physics simulation.\n",
+      "    \n",
+      "    def __init__(self, x=0, y=0):\n",
+      "        # Each rocket has an (x,y) position.\n",
+      "        self.x = x\n",
+      "        self.y = y\n",
+      "        \n",
+      "    def move_rocket(self, x_increment=0, y_increment=1):\n",
+      "        # Move the rocket according to the paremeters given.\n",
+      "        #  Default behavior is to move the rocket up one unit.\n",
+      "        self.x += x_increment\n",
+      "        self.y += y_increment\n",
+      "        \n",
+      "    def get_distance(self, other_rocket):\n",
+      "        # Calculates the distance from this rocket to another rocket,\n",
+      "        #  and returns that value.\n",
+      "        distance = sqrt((self.x-other_rocket.x)**2+(self.y-other_rocket.y)**2)\n",
+      "        return distance"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 48
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import Rocket\n",
+      "\n",
+      "rocket = Rocket()\n",
+      "print(rocket)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "ename": "ImportError",
+       "evalue": "No module named 'Rocket'",
+       "output_type": "pyerr",
+       "traceback": [
+        "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[1;31mImportError\u001b[0m                               Traceback (most recent call last)",
+        "\u001b[1;32m<ipython-input-49-1867f2f45d4e>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[1;32mimport\u001b[0m \u001b[0mRocket\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      2\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      3\u001b[0m \u001b[0mrocket\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mRocket\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mrocket\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+        "\u001b[1;31mImportError\u001b[0m: No module named 'Rocket'"
+       ]
+      }
+     ],
+     "prompt_number": 49
     },
     {
      "cell_type": "markdown",


### PR DESCRIPTION
This starts the section on importing classes and modules. It would be nice for these examples if we could import from a previous cell, but in a normal ipynb there is no need to do that, because all cells share a namespace.

This means we have to keep any modules that need to be imported in a file in the /notebooks directory. This introduces redundancy, which will be important to stay aware of. For example, the section asks readers to save rocket.py as a module, and import rocket into rocket_game.py. The code for rocket.py is shown in the notebook, but it also needs to be saved in the /notebooks directory for the `import rocket` command to work in the next cell.
