### PR TITLE
Removed links to Contents and Syllabus pages.

### DIFF
--- a/notebooks/my_templates/navbar.html
+++ b/notebooks/my_templates/navbar.html
@@ -18,10 +18,6 @@
               <ul class="dropdown-menu">
 
                 <li class="divider"></li>
-                <li><a href="contents.html">Contents</a></li>
-                <li><a href="syllabus.html">Syllabus</a></li>
-
-                <li class="divider"></li>
                 <li><a href="programming_environment.html">Programming Environment</a></li>
                 <li><a href="programming_environment_linux.html">&nbsp&nbspLinux</a></li>
                 <li><a href="programming_environment.html#mac">&nbsp&nbspMac</a></li>


### PR DESCRIPTION
These pages were not very helpful; it's pretty clear from the navigation bar what's covered in the project. I left the notebooks in, though, because they could be made more useful.