### PR TITLE
docs: Fix a few typos

### DIFF
--- a/notebooks/rocket.py
+++ b/notebooks/rocket.py
@@ -10,7 +10,7 @@ class Rocket():
         self.y = y
         
     def move_rocket(self, x_increment=0, y_increment=1):
-        # Move the rocket according to the paremeters given.
+        # Move the rocket according to the parameters given.
         #  Default behavior is to move the rocket up one unit.
         self.x += x_increment
         self.y += y_increment

--- a/scripts/highlight_code.py
+++ b/scripts/highlight_code.py
@@ -24,7 +24,7 @@
 # The script assumes all html files are not nested, in a directory called
 #  'notebooks'.
 
-# You will need to specificy path_to_notebooks.
+# You will need to specify path_to_notebooks.
 # I'm happy to hear feedback, and accept improvements:
 # https://github.com/ehmatthes/intro_programming
 # ehmatthes@gmail.com, @ehmatthes


### PR DESCRIPTION
There are small typos in:
- notebooks/rocket.py
- scripts/highlight_code.py

Fixes:
- Should read `specify` rather than `specificy`.
- Should read `parameters` rather than `paremeters`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md